### PR TITLE
fix: update fixup for stencil

### DIFF
--- a/fixup.sh
+++ b/fixup.sh
@@ -1,10 +1,15 @@
 echo >dist/cjs/package.json '{
   "type": "commonjs",
-	"typings": "dist/cjs/index.d.ts"
+	"typings": "./index.d.ts",
+	"browser": {
+		"./crypto": "./crypto.browser"
+	}
 }'
 
 echo >dist/mjs/package.json '{
   "type": "module",
-	"typings": "dist/mjs/index.d.ts"
+	"typings": "./index.d.ts",
+	"browser": {
+		"./crypto": "./crypto.browser"
+	}
 }'
-

--- a/fixup.sh
+++ b/fixup.sh
@@ -13,3 +13,4 @@ echo >dist/mjs/package.json '{
 		"./crypto": "./crypto.browser"
 	}
 }'
+


### PR DESCRIPTION
Stencil has trouble resolving browser polyfill for crypto unless placed in "inner" package.json in dist folders.