### PR TITLE
Revert encoding standard export/import option for key

### DIFF
--- a/Encrypter/Rsa/index.spec.ts
+++ b/Encrypter/Rsa/index.spec.ts
@@ -60,26 +60,4 @@ describe("Encrypter.Rsa", () => {
 			fail()
 		}
 	})
-	it("encrypt & decrypt RSA OAEP with imported key, export/import both keys at once, URL encoding", async () => {
-		const generated = cryptly.Encrypter.Rsa.generate(2048)
-
-		const keys = await generated.export("url")
-		const privateKey = keys.private
-		const publicKey = keys.public
-		expect(keys).toBeDefined()
-		if (keys && privateKey && publicKey) {
-			const encrypter = cryptly.Encrypter.Rsa.import(publicKey, privateKey, "url")
-			const encrypted = await encrypter.encrypt("The meaning of life, the universe and everything.")
-			expect(encrypted).toBeDefined()
-			if (encrypted) {
-				expect(encrypted.value).toHaveLength(342)
-				const decrypted = await encrypter.decrypt(encrypted)
-				expect(decrypted).toEqual("The meaning of life, the universe and everything.")
-			} else {
-				fail()
-			}
-		} else {
-			fail()
-		}
-	})
 })

--- a/Encrypter/Rsa/index.ts
+++ b/Encrypter/Rsa/index.ts
@@ -40,41 +40,27 @@ export class Rsa {
 			  )
 			: undefined
 	}
-	async export(type: "private" | "public", standard?: Base64.Standard): Promise<string | undefined>
-	async export(standard?: Base64.Standard): Promise<{ public: string | undefined; private: string | undefined }>
+	async export(type: "private" | "public"): Promise<string | undefined>
+	async export(): Promise<{ public: string | undefined; private: string | undefined }>
 	async export(
-		type?: "private" | "public" | Base64.Standard,
-		standard?: Base64.Standard
+		type?: "private" | "public"
 	): Promise<string | undefined | { public: string | undefined; private: string | undefined }> {
-		return type == "private" || type == "public"
-			? (await this.keys)[type]?.export(standard && { type: "base64", standard: standard ?? "standard" })
+		return type
+			? (await this.keys)[type]?.export()
 			: Object.fromEntries(
-					await Promise.all(
-						Object.entries(await this.keys).map(async ([keyType, key]) => [
-							keyType,
-							await key?.export(type && { type: "base64", standard: type ?? "standard" }),
-						])
-					)
+					await Promise.all(Object.entries(await this.keys).map(async ([type, key]) => [type, await key?.export()]))
 			  )
 	}
 	static generate(key: 1024 | 2048 | 4096): Rsa {
 		return new Rsa(Key.Rsa.generate(key))
 	}
-	static import(type: "public" | "private", key: string | ArrayBuffer, encodingStandard?: Base64.Standard): Rsa
-	static import(
-		publicKey: string | ArrayBuffer,
-		privateKey: string | ArrayBuffer,
-		encodingStandard?: Base64.Standard
-	): Rsa
-	static import(
-		type: "public" | "private" | string | ArrayBuffer,
-		key: string | ArrayBuffer,
-		encodingStandard?: Base64.Standard
-	): Rsa {
+	static import(type: "public" | "private", key: string | ArrayBuffer): Rsa
+	static import(publicKey: string | ArrayBuffer, privateKey: string | ArrayBuffer): Rsa
+	static import(type: "public" | "private" | string | ArrayBuffer, key: string | ArrayBuffer): Rsa {
 		return new Rsa(
 			type == "public" || type == "private"
-				? Key.Rsa.import(type, key, undefined, undefined, encodingStandard).then(result => ({ [type]: result }))
-				: Key.Rsa.Pair.load(type, key, encodingStandard)
+				? Key.Rsa.import(type, key).then(result => ({ [type]: result }))
+				: Key.Rsa.Pair.load(type, key)
 		)
 	}
 }

--- a/Signer/Rsa.spec.ts
+++ b/Signer/Rsa.spec.ts
@@ -23,8 +23,8 @@ describe("Algorithm.RS256", () => {
 		const algorithm = Signer.generate("RSA", "SHA-256", 1024)
 		expect(await algorithm.verify(message, await algorithm.sign(message))).toEqual(true)
 		const exported = {
-			public: await algorithm.export("public", { type: "base64", standard: "standard" }),
-			private: await algorithm.export("private", { type: "base64", standard: "standard" }),
+			public: await algorithm.export("public", "base64"),
+			private: await algorithm.export("private", "base64"),
 		}
 		expect(exported.public).toMatch(/MI[A-Z,a-z,0-9,+,/]+=*/g)
 		expect(exported.private).toMatch(/MI[A-Z,a-z,0-9,+,/]+=*/g)

--- a/Signer/Rsa.ts
+++ b/Signer/Rsa.ts
@@ -1,4 +1,3 @@
-import { Standard } from "../Base64"
 import { crypto } from "../crypto"
 import { Key } from "../Key"
 import { Base } from "./Base"
@@ -18,13 +17,10 @@ export class Rsa extends Base {
 	}
 	async export(type: "private" | "public", format: "jwk"): Promise<JsonWebKey | undefined>
 	async export(type: "private" | "public", format: "buffer"): Promise<ArrayBuffer | undefined>
+	async export(type: "private" | "public", format?: "base64" | "pem"): Promise<string | undefined>
 	async export(
 		type: "private" | "public",
-		format?: { type: "base64"; standard: Standard } | "pem"
-	): Promise<string | undefined>
-	async export(
-		type: "private" | "public",
-		format: "jwk" | "buffer" | { type: "base64"; standard: Standard } | "pem" = { type: "base64", standard: "standard" }
+		format: "jwk" | "buffer" | "base64" | "pem" = "base64"
 	): Promise<JsonWebKey | ArrayBuffer | string | undefined> {
 		const key = (await this.keys)[type]
 		return key?.export(format)
@@ -33,13 +29,12 @@ export class Rsa extends Base {
 		variant: Key.Rsa.Variant,
 		hash: Hash,
 		publicKey: Uint8Array | string | undefined,
-		privateKey?: Uint8Array | string,
-		encodingStandard?: Standard
+		privateKey?: Uint8Array | string
 	): Rsa {
 		return new Rsa(
 			Promise.all([
-				Key.Rsa.import("public", publicKey, variant, hash, encodingStandard),
-				Key.Rsa.import("private", privateKey, variant, hash, encodingStandard),
+				Key.Rsa.import("public", publicKey, variant, hash),
+				Key.Rsa.import("private", privateKey, variant, hash),
 			]).then(([publicKey, privateKey]) => ({
 				public: publicKey,
 				private: privateKey,


### PR DESCRIPTION
Reverts previous extension regarding allowing selection of encoding standard when exporting or importing keys. This was unnecessary as we can always use the standard encoding for base64.